### PR TITLE
Dockerize output jar 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM java:11
+COPY target/spring-app-0.0.1-SNAPSHOT.jar /app/spring-app.jar
+EXPOSE 9001
+CMD ["java","-jar","app/spring-app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:11
+FROM openjdk:11-jdk-slim
 COPY target/spring-app-0.0.1-SNAPSHOT.jar /app/spring-app.jar
 EXPOSE 9001
 CMD ["java","-jar","app/spring-app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  springboot:
+    build: .
+    ports:
+      - "9001:9001"

--- a/src/main/java/com/elk/controller/ELKController.java
+++ b/src/main/java/com/elk/controller/ELKController.java
@@ -25,7 +25,7 @@ public class ELKController {
 		}
 	}
 	
-	@PostMapping(value="messgae/{messageVal}")
+	@PostMapping(value="message/{messageVal}")
 	public ResponseEntity<String> postMessageValue(@PathVariable ("messageVal") String messageVal) {
 		try {
 			//MessageTemplate msg = new MessageTemplate(messageVal, "1");
@@ -36,7 +36,7 @@ public class ELKController {
 		}
 	}
 	
-	@DeleteMapping(value="messgae/{messageId}")
+	@DeleteMapping(value="message/{messageId}")
 	public ResponseEntity<String> deleteMessageIdValue(@PathVariable ("messageId") String messageId) {
 		try {
 			//MessageTemplate msg = new MessageTemplate(messageVal, "1");

--- a/src/main/java/com/elk/model/MessageTemplate.java
+++ b/src/main/java/com/elk/model/MessageTemplate.java
@@ -2,7 +2,7 @@ package com.elk.model;
 
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
+//@AllArgsConstructor
 public class MessageTemplate {
 	
 	private String message;


### PR DESCRIPTION
Issue: #7 

Docker:
- Added Dockerfile to build output jar (jar obtained in build is included in the commit (in same directory as Dockerfile) for reference, Dockerfile points to output jar in /target file)
  - no alpine build for openjdk 11 so [jdk-11-slim](https://github.com/docker-library/openjdk/issues/313) is used instead
  - command used 
  - >docker build -t springboot:1.0 .
docker run -d -p 9001:9001 -t springboot:1.0
- Added docker-compose.yml 
  - command used: `docker-compose up`

Other changes:
- Fixed incorrect spelling of message in controller
- commented out AllArgsConstructor annotation in message template